### PR TITLE
Chore: Spring Security 기본 설정 및 모든 API 허용 (#4)

### DIFF
--- a/BE/backend/src/main/java/com/techpick/backend/common/config/SecurityConfig.java
+++ b/BE/backend/src/main/java/com/techpick/backend/common/config/SecurityConfig.java
@@ -1,0 +1,50 @@
+package com.techpick.backend.common.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(Customizer.withDefaults())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth
+                        .anyRequest().permitAll() // 현재는 모든 API 개방
+                );
+        return http.build();
+    }
+
+    // 프론트엔드와 연결할 때 에러가 나지 않도록 설정
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(List.of("http://localhost:3000", "http://localhost:5173"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+}


### PR DESCRIPTION
## 📌 개요
- 작업 내용: Spring Security 기본 설정 및 전역 인증 해제
- 이슈 번호: Closes #4 

## ✨ 작업 사항
- [x] Spring Security 의존성 기반 설정 : SecurityConfig 클래스 생성을 통해 프로젝트 보안 기본 구조 설정
- [x] 전역 접근 허용
- [x] Statless 세션 정책 적용
- [x]CORS 설정 추가 : 프론트엔드 개발 환경과의 원활한 통신을 위한 리소스 공유 허용 

## 📚 참고 사항
세션 정책이 STATELESS이므로, 추후 사용자 식별 기능이 추가될 경우, JWT 등 토큰 기반 인증 방식을 도입하기 용이한 구조
