### PR TITLE
[Feat] 아티클 목록 조회 API 구현 (#3)

### DIFF
--- a/BE/backend/src/main/java/com/techpick/backend/article/controller/ArticleController.java
+++ b/BE/backend/src/main/java/com/techpick/backend/article/controller/ArticleController.java
@@ -1,12 +1,16 @@
 package com.techpick.backend.article.controller;
 
 import com.techpick.backend.article.dto.request.ArticleRequest;
+import com.techpick.backend.article.dto.response.ArticleListResponse;
 import com.techpick.backend.article.dto.response.ArticleResponse;
 import com.techpick.backend.article.service.ArticleService;
 import com.techpick.backend.common.apiPayload.ApiResponse;
 import com.techpick.backend.common.apiPayload.code.status.SuccessStatus;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/articles")
@@ -15,6 +19,11 @@ public class ArticleController {
 
     private final ArticleService articleService;
 
+    /**
+     * 아티클 생성
+     * @param request
+     * @return
+     */
     @PostMapping
     public ApiResponse<ArticleResponse> createArticle(@RequestBody ArticleRequest request){
         ArticleResponse response = articleService.createArticle(request);
@@ -22,10 +31,26 @@ public class ArticleController {
         return ApiResponse.onSuccess(response);
     }
 
+    /**
+     * 아티클 상세 조회
+     * @param articleId
+     * @return
+     */
     @GetMapping("/{articleId}")
     public ApiResponse<ArticleResponse> getArticleDetail(@PathVariable Long articleId){
         ArticleResponse response = articleService.getArticleDetail(articleId);
         return ApiResponse.of(SuccessStatus.ARTICLE_DETAIL_SUCCESS, response);
+    }
+
+    @GetMapping
+    public ApiResponse<ArticleListResponse> getAllArticles(
+            @RequestParam(name = "page", defaultValue = "0") int page,
+            @RequestParam(name = "size", defaultValue = "10") int size
+    ){
+        // Service를 호출하여 페이징된 결과 가져오기
+        ArticleListResponse response = articleService.getAllArticles(page, size);
+
+        return ApiResponse.of(SuccessStatus.ARTICLE_LIST_SUCCESS, response);
     }
 
 }

--- a/BE/backend/src/main/java/com/techpick/backend/article/dto/request/ArticleRequest.java
+++ b/BE/backend/src/main/java/com/techpick/backend/article/dto/request/ArticleRequest.java
@@ -13,4 +13,7 @@ public class ArticleRequest {
     private String title;
     private String content;
     private String url;
+    private String pubDate;
+    private String blogName;
+    private String thumbnailUrl;
 }

--- a/BE/backend/src/main/java/com/techpick/backend/article/dto/response/ArticleListResponse.java
+++ b/BE/backend/src/main/java/com/techpick/backend/article/dto/response/ArticleListResponse.java
@@ -1,0 +1,19 @@
+package com.techpick.backend.article.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ArticleListResponse {
+    private List<ArticleResponse> articles;
+    private int listSize;
+    private int totalPages;
+    private long totalElements;
+    private boolean isFirst;
+    private boolean isLast;
+}

--- a/BE/backend/src/main/java/com/techpick/backend/article/entity/Article.java
+++ b/BE/backend/src/main/java/com/techpick/backend/article/entity/Article.java
@@ -39,5 +39,6 @@ public class Article {
     @Column(nullable = false)
     private String thumbnailUrl;
 
+    @Column(nullable = false)
     private LocalDateTime createdAt;
 }

--- a/BE/backend/src/main/java/com/techpick/backend/article/service/ArticleService.java
+++ b/BE/backend/src/main/java/com/techpick/backend/article/service/ArticleService.java
@@ -1,6 +1,7 @@
 package com.techpick.backend.article.service;
 
 import com.techpick.backend.article.dto.request.ArticleRequest;
+import com.techpick.backend.article.dto.response.ArticleListResponse;
 import com.techpick.backend.article.dto.response.ArticleResponse;
 import com.techpick.backend.article.entity.Article;
 import com.techpick.backend.article.repository.ArticleRepository;
@@ -10,7 +11,13 @@ import jakarta.transaction.Transactional;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -19,6 +26,11 @@ public class ArticleService {
 
     private final ArticleRepository articleRepository;
 
+    /**
+     * 아티클 생성
+     * @param request
+     * @return
+     */
     public ArticleResponse createArticle(ArticleRequest request) {
 
         Article article = Article.builder()
@@ -36,9 +48,43 @@ public class ArticleService {
                 .build();
     }
 
+    /**
+     * 아티클 상세 조회
+     * @param articleId
+     * @return
+     */
     public ArticleResponse getArticleDetail(Long articleId) {
         Article article = articleRepository.findById(articleId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.ARTICLE_NOT_FOUND));
         return ArticleResponse.from(article);
+    }
+
+    /**
+     * 아티클 목록 조회
+     * @param page
+     * @param size
+     * @return
+     */
+    public ArticleListResponse getAllArticles(int page, int size) {
+        // 페이징 및 정렬 설정 (최신순)
+        PageRequest pageRequest = PageRequest.of(page, size, Sort.by("createdAt").descending());
+
+        // DB에서 페이징된 데이터 가져오기
+        Page<Article> articlePage = articleRepository.findAll(pageRequest);
+
+        // Entity 리스트를 Response DTO 리스트로 변환
+        List<ArticleResponse> articleResponses = articlePage.getContent().stream()
+                .map(ArticleResponse::from)
+                .collect(Collectors.toList());
+
+        // DTO 구조에 맞춰 변환
+        return ArticleListResponse.builder()
+                .articles(articleResponses)
+                .listSize(articleResponses.size())
+                .totalPages(articlePage.getTotalPages())
+                .totalElements(articlePage.getTotalElements())
+                .isFirst(articlePage.isFirst())
+                .isLast(articlePage.isLast())
+                .build();
     }
 }

--- a/BE/backend/src/main/java/com/techpick/backend/article/service/ArticleService.java
+++ b/BE/backend/src/main/java/com/techpick/backend/article/service/ArticleService.java
@@ -8,15 +8,15 @@ import com.techpick.backend.article.repository.ArticleRepository;
 import com.techpick.backend.common.apiPayload.code.status.ErrorStatus;
 import com.techpick.backend.common.apiPayload.exception.GeneralException;
 import jakarta.transaction.Transactional;
-import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
+import java.time.ZoneOffset;
 import java.util.List;
+import java.time.LocalDateTime;
 import java.util.stream.Collectors;
 
 @Service
@@ -37,6 +37,10 @@ public class ArticleService {
                 .title(request.getTitle())
                 .content(request.getContent())
                 .url(request.getUrl())
+                .pubDate(request.getPubDate())
+                .blogName(request.getBlogName())
+                .thumbnailUrl(request.getThumbnailUrl())
+                .createdAt(LocalDateTime.now(ZoneOffset.UTC))
                 .build();
 
         Article savedArticle = articleRepository.save(article);
@@ -45,6 +49,9 @@ public class ArticleService {
                 .articleId(savedArticle.getArticleId())
                 .title(savedArticle.getTitle())
                 .url(savedArticle.getUrl())
+                .pubDate(savedArticle.getPubDate())
+                .blogName(savedArticle.getBlogName())
+                .thumbnailUrl(savedArticle.getThumbnailUrl())
                 .build();
     }
 

--- a/BE/backend/src/main/java/com/techpick/backend/common/apiPayload/code/status/SuccessStatus.java
+++ b/BE/backend/src/main/java/com/techpick/backend/common/apiPayload/code/status/SuccessStatus.java
@@ -18,7 +18,8 @@ public enum SuccessStatus implements BaseCode {
     USER_INFO_SUCCESS(HttpStatus.OK, "USER2001", "사용자 정보 조회 성공입니다."),
 
     // 아티클 관련 응답
-    ARTICLE_DETAIL_SUCCESS(HttpStatus.OK, "ARTICLE2001", "아티클 상세 조회 성공입니다.");
+    ARTICLE_DETAIL_SUCCESS(HttpStatus.OK, "ARTICLE2001", "아티클 상세 조회 성공입니다."),
+    ARTICLE_LIST_SUCCESS(HttpStatus.OK, "ARTICLE2002", "아티클 전체 조회 성공입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/BE/backend/src/test/java/com/techpick/backend/article/controller/ArticleControllerTest.java
+++ b/BE/backend/src/test/java/com/techpick/backend/article/controller/ArticleControllerTest.java
@@ -2,6 +2,7 @@ package com.techpick.backend.article.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.techpick.backend.article.dto.request.ArticleRequest;
+import com.techpick.backend.article.dto.response.ArticleListResponse;
 import com.techpick.backend.article.dto.response.ArticleResponse;
 import com.techpick.backend.article.service.ArticleService;
 import org.junit.jupiter.api.DisplayName;
@@ -12,6 +13,8 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -82,4 +85,43 @@ public class ArticleControllerTest {
                 .andExpect(jsonPath("$.result.articleId").value(articleId));
     }
 
+    @Test
+    @WithMockUser
+    @DisplayName("아티클 목록을 조회하면 페이징된 결과를 응답한다")
+    void getAllArticles() throws Exception {
+        //Given
+        int page = 0;
+        int size = 10;
+
+        ArticleResponse article1 = ArticleResponse.builder()
+                .articleId(1L).title("제목1").url("https://test1.com").build();
+        ArticleResponse article2 = ArticleResponse.builder()
+                .articleId(2L).title("제목2").url("https://test2.com").build();
+
+        ArticleListResponse response = ArticleListResponse.builder()
+                .articles(List.of(article1, article2))
+                .listSize(2)
+                .totalPages(1)
+                .totalElements(2)
+                .isFirst(true)
+                .isLast(true)
+                .build();
+
+        // articleService.getAllArticles 호출 시 mock 응답 설정
+        given(articleService.getAllArticles(page, size)).willReturn(response);
+
+        //When & Then
+        mockMvc.perform(get("/api/articles")
+                .param("page", String.valueOf(page))
+                .param("size", String.valueOf(size)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.result.articles").isArray())
+                .andExpect(jsonPath("$.result.listSize").value(2))
+                .andExpect(jsonPath("$.result.totalPages").value(1))
+                .andExpect(jsonPath("$.result.totalElements").value(2))
+                .andExpect(jsonPath("$.result.first").value(true))
+                .andExpect(jsonPath("$.result.articles[0].title").value("제목1"));
+
+    }
 }

--- a/BE/backend/src/test/java/com/techpick/backend/article/service/ArticleServiceTest.java
+++ b/BE/backend/src/test/java/com/techpick/backend/article/service/ArticleServiceTest.java
@@ -1,6 +1,7 @@
 package com.techpick.backend.article.service;
 
 import com.techpick.backend.article.dto.request.ArticleRequest;
+import com.techpick.backend.article.dto.response.ArticleListResponse;
 import com.techpick.backend.article.dto.response.ArticleResponse;
 import com.techpick.backend.article.entity.Article;
 import com.techpick.backend.article.repository.ArticleRepository;
@@ -9,11 +10,19 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(SpringExtension.class)
@@ -45,5 +54,41 @@ public class ArticleServiceTest {
         assertThat(response.getArticleId()).isEqualTo(1L);
         assertThat(response.getTitle()).isEqualTo("제목");
         verify(articleRepository).save(any(Article.class));
+    }
+
+    @Test
+    @DisplayName("아티클 목록을 조회하면 페이징 정보가 포함된 DTO를 반환한다")
+    void getAllArticles() {
+        //Given
+        int page = 0;
+        int size = 10;
+        PageRequest pageRequest = PageRequest.of(page, size, Sort.by("createdAt").descending());
+
+        Article article = Article.builder()
+                .articleId(1L)
+                .title("제목")
+                .url("https://test.com")
+                .content("내용")
+                .blogName("테스트 블로그")
+                .pubDate("2026-02-03")
+                .thumbnailUrl("https://thumb.com")
+                .build();
+
+        //Mock Repository가 Page 객체를 반환하도록 설정
+        Page<Article> articlePage = new PageImpl<>(List.of(article), pageRequest, 1);
+        given(articleRepository.findAll(any(PageRequest.class))).willReturn(articlePage);
+
+        //When
+        ArticleListResponse response = articleService.getAllArticles(page, size);
+
+        //Then
+        assertThat(response.getArticles()).hasSize(1);
+        assertThat(response.getListSize()).isEqualTo(1);
+        assertThat(response.getTotalPages()).isEqualTo(1);
+        assertThat(response.isFirst()).isTrue();
+        assertThat(response.getArticles().get(0).getTitle()).isEqualTo("제목");
+
+        // Repository 호출 여부 검증
+        verify(articleRepository, times(1)).findAll(any(PageRequest.class));
     }
 }


### PR DESCRIPTION
## 📌 개요
- 작업 내용: 아티클 목록 조회 API 구현
- 이슈 번호: Closes #3 

## ✨ 작업 사항
- [x] Spring Data JPA Pageable을 이용한 페이징 처리
- [x] createdAt 시간대 통일 및 수정
- [x] ArticleRequest에 필드 추가  

## 📚 참고 사항
