### PR TITLE
[FIX] 익명 유저 UUID 로직 수정 (#9)

### DIFF
--- a/BE/backend/src/main/java/com/techpick/backend/user/service/UserService.java
+++ b/BE/backend/src/main/java/com/techpick/backend/user/service/UserService.java
@@ -6,6 +6,8 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.UUID;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -14,6 +16,9 @@ public class UserService {
     private final UserRepository userRepository;
 
     public User findOrCreateUser(String userUuid) {
+        if (userUuid == null || userUuid.isBlank()) {
+            return userRepository.save(new User(UUID.randomUUID().toString()));
+        }
         return userRepository.findByUserUuid(userUuid)
                 .orElseGet(() -> userRepository.save(new User(userUuid)));
     }

--- a/BE/backend/src/test/java/com/techpick/backend/user/controller/UserControllerTest.java
+++ b/BE/backend/src/test/java/com/techpick/backend/user/controller/UserControllerTest.java
@@ -58,4 +58,26 @@ public class UserControllerTest {
 
 
     }
+
+    @Test
+    @WithMockUser
+    @DisplayName("UUID 없이 요청하면 서버가 생성한 UUID를 응답한다")
+    void loginWithoutUuid() throws Exception {
+
+        //Given
+        String newUuid = UUID.randomUUID().toString();
+        User user = new User(newUuid);
+        UserRequest request = new UserRequest(null);
+
+        given(userService.findOrCreateUser(null)).willReturn(user);
+
+        //When & Then
+        mockMvc.perform(post("/api/users")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.result.userUuid").isNotEmpty());
+    }
 }

--- a/BE/backend/src/test/java/com/techpick/backend/user/service/UserServiceTest.java
+++ b/BE/backend/src/test/java/com/techpick/backend/user/service/UserServiceTest.java
@@ -15,6 +15,7 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 
@@ -43,4 +44,24 @@ public class UserServiceTest {
         verify(userRepository, times(1)).save(any(User.class));
     }
 
+    @Test
+    @DisplayName("UUID 없이 요청하면 서버가 UUID를 생성해서 저장한다")
+    void updateUser() {
+
+        //Given
+        String userUuid = null;
+        User savedUser = User.builder()
+                .userUuid(UUID.randomUUID().toString())
+                .build();
+
+        given(userRepository.save(any(User.class))).willReturn(savedUser);
+
+        //When
+        User result = userService.findOrCreateUser(userUuid);
+
+        //Then
+        verify(userRepository, never()).findByUserUuid(any());
+        verify(userRepository, times(1)).save(any());
+        assertThat(result.getUserUuid()).isNotNull();
+    }
 }


### PR DESCRIPTION
## 📌 개요
- 작업 내용: 익명 유저 식별을 위한 UUID를 클라이언트가 아닌 서버에서 생성하도록 수정
- 이슈 번호: Closes #9

## ✨ 작업 사항
- [ ] UUID가 null 또는 blank로 요청 시 서버에서 UUID 생성 후. ㅏㄴ환
- [ ] 기존 UUID가 있으면 조회 후 반환하는 로직 유지
- [ ] UserServiceTest - UUID 없이 요청 시 서버 생성 테스트 추가
- [ ] UserControllerTest - 빈 body 요청 시 정상 응답 테스트 추가

## 📚 참고 사항
